### PR TITLE
Use XCode 10.2 in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 matrix:
   include:
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode10.2
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 


### PR DESCRIPTION
Using XCode 10.0 triggers compatibility errors between Git and Homebrew.